### PR TITLE
CVE vulnerability upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /checkouts
 /target
 .nrepl-port
+.idea/
+clj-excel.iml

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Creating links:
 
 ```clojure
 ;; just the data
-{"a" [[{:value "foo" :link-document "b!A1"}]]
- "b" [[{:value "example.com" :link-url "http://www.example.com/"}]]}
+{"a" [[{:value "foo" :document "b!A1"}]]
+ "b" [[{:value "example.com" :url "http://www.example.com/"}]]}
 ```
 
 Creating comments:

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject grafter/clj-excel "0.0.10-SNAPSHOT"
+(defproject grafter/clj-excel "0.0.11"
   :description "Excel bindings for Clojure, based on Apache POI."
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apache.poi/poi "3.9"]
-                 [org.apache.poi/poi-ooxml "3.9"]]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [org.apache.poi/poi "5.2.2"]
+                 [org.apache.poi/poi-ooxml "5.2.2"]]
   :profiles {:dev {:source-paths ["dev"]
                    :resource-paths ["test-resources"]
                    :plugins [[lein-cloverage "1.0.2"]]


### PR DESCRIPTION
This fork of clj-excel is essentially deprecated. However it is likely to remain in use for the next 12 - 18 months, so the core dependencies have been upgraded in order to address CVE security vulnerabilities.